### PR TITLE
Implement CSRF protection for comment actions

### DIFF
--- a/add_comment.php
+++ b/add_comment.php
@@ -12,6 +12,11 @@ if ($_SERVER["REQUEST_METHOD"] != "POST" || !isset($_POST['sticker_id']) || !iss
     exit();
 }
 
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+    echo json_encode(['status' => 'error', 'message' => 'invalid_token']);
+    exit();
+}
+
 $sticker_id = intval($_POST['sticker_id']);
 $comment_text = trim($_POST['comment']);
 $parent_id = isset($_POST['parent_id']) && !empty($_POST['parent_id']) ? intval($_POST['parent_id']) : null;

--- a/admin_header.php
+++ b/admin_header.php
@@ -1,5 +1,8 @@
 <?php
 session_start();
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== true) {
     header("Location: login.php");
     exit;

--- a/delete_comment.php
+++ b/delete_comment.php
@@ -10,6 +10,11 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['comment_id'])) {
     exit;
 }
 
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+    echo json_encode(['status' => 'error', 'message' => 'invalid_token']);
+    exit;
+}
+
 $comment_id = intval($_POST['comment_id']);
 $current_user_id = $_SESSION['user_id'] ?? 0;
 $is_admin = isset($_SESSION['admin_logged_in']) && $_SESSION['admin_logged_in'] === true;

--- a/edit_comment.php
+++ b/edit_comment.php
@@ -46,11 +46,11 @@ if (!$is_admin && $current_user_id != $comment_owner_id) {
         <h1>Rəyi Redaktə Et</h1>
         <form action="update_comment.php" method="POST" class="edit-form">
             <input type="hidden" name="id" value="<?php echo $comment_id; ?>">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
             <label for="comment">Rəy:</label>
             <textarea id="comment" name="comment" rows="6" required><?php echo htmlspecialchars($comment_data['comment']); ?></textarea>
             <button type="submit">Yadda Saxla</button>
             <a href="javascript:history.back()" class="back-link">Geri Qayıt</a>
         </form>
     </div>
-</body>
-</html>
+</body></html>

--- a/head.php
+++ b/head.php
@@ -4,6 +4,11 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
+// Sessiyada CSRF tokeni yaradılır
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 if (!defined('PROJECT_ROOT')) {
     require_once __DIR__ . '/db.php'; 
 }

--- a/like_comment.php
+++ b/like_comment.php
@@ -18,6 +18,11 @@ if ($_SERVER["REQUEST_METHOD"] != "POST" || !isset($_POST['id']) || !isset($_POS
     exit();
 }
 
+if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+    echo json_encode(['status' => 'error', 'message' => 'invalid_token']);
+    exit();
+}
+
 $comment_id = intval($_POST['id']);
 $sticker_id = intval($_POST['sticker_id']);
 $actor_user_id = $_SESSION['user_id'];

--- a/script.js
+++ b/script.js
@@ -222,7 +222,8 @@ $(document).ready(function() {
                 url: 'like_comment.php',
                 data: {
                     id: comment_id,
-                    sticker_id: stickerId
+                    sticker_id: stickerId,
+                    csrf_token: csrfToken
                 },
                 dataType: 'json',
                 success: function(response) {
@@ -258,7 +259,7 @@ $(document).ready(function() {
             if (!confirm('Bu rəyi və ona yazılan bütün cavabları silməyə əminsiniz?')) { return; }
             var button = $(this); var comment_id = button.data('id'); var comment_element = button.closest('.comment');
             $.ajax({
-                type: 'POST', url: 'delete_comment.php', data: { comment_id: comment_id }, dataType: 'json',
+                type: 'POST', url: 'delete_comment.php', data: { comment_id: comment_id, csrf_token: csrfToken }, dataType: 'json',
                 success: function(response) {
                     if (response.status === 'success') { comment_element.fadeOut(500, function() { $(this).remove(); }); } 
                     else { alert("Xəta: " + response.message); }

--- a/update_comment.php
+++ b/update_comment.php
@@ -3,6 +3,9 @@ session_start();
 require 'db.php';
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
     $comment_id = intval($_POST['id']);
     $comment_text = trim($_POST['comment']);
     

--- a/update_settings.php
+++ b/update_settings.php
@@ -5,7 +5,9 @@ if (!isset($_SESSION['admin_logged_in']) || $_SESSION['admin_logged_in'] !== tru
 require 'db.php';
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['settings']) && is_array($_POST['settings'])) {
-    // ... (CSRF yoxlamanız burada olmalıdır) ...
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== ($_SESSION['csrf_token'] ?? '')) {
+        exit('Invalid CSRF token');
+    }
 
     $stmt = $conn->prepare("UPDATE settings SET setting_value = ? WHERE setting_key = ?");
     
@@ -18,5 +20,4 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['settings']) && is_arra
     $stmt->close();
     header("Location: settings.php?success=1");
     exit();
-}
-?>
+}?>

--- a/view_sticker.php
+++ b/view_sticker.php
@@ -143,6 +143,7 @@ $sticker_page_url = $protocol . "://" . $_SERVER['HTTP_HOST'] . "/fikir/" . $sti
 
     <form id="comment-form" accept-charset="UTF-8">
         <input type="hidden" name="sticker_id" value="<?php echo $sticker_id; ?>">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
         <?php if (isset($_SESSION['user_id'])): ?>
             <div class="logged-in-as">
                 <img src="<?php echo htmlspecialchars($_SESSION['user_picture']); ?>" alt="Profil şəkli">
@@ -245,6 +246,7 @@ $sticker_page_url = $protocol . "://" . $_SERVER['HTTP_HOST'] . "/fikir/" . $sti
 <div id="reply-form-template" style="display: none;">
     <form class="reply-form" method="POST" action="add_comment.php">
         <input type="hidden" name="sticker_id" value="<?php echo $sticker_id; ?>">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
         <input type="hidden" class="parent-id-input" name="parent_id" value="">
         <textarea name="comment" rows="3" placeholder="Cavabınızı yazın..." required></textarea>
         <div class="reply-form-actions">
@@ -254,7 +256,10 @@ $sticker_page_url = $protocol . "://" . $_SERVER['HTTP_HOST'] . "/fikir/" . $sti
     </form>
 </div>
 
-<script>var stickerId = <?php echo json_encode($sticker_id); ?>;</script>
+<script>
+var stickerId = <?php echo json_encode($sticker_id); ?>;
+var csrfToken = <?php echo json_encode($_SESSION['csrf_token']); ?>;
+</script>
 
 <?php require 'footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- generate CSRF tokens in `head.php` and `admin_header.php`
- embed tokens into comment forms and reply forms
- expose token to JS and send it with AJAX requests
- verify tokens in comment related PHP endpoints and settings update

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e84210c64833399660fb8e2f4d091