### PR TITLE
Improve daily game with timer display

### DIFF
--- a/oyun/index.php
+++ b/oyun/index.php
@@ -30,6 +30,7 @@ $can_play = (!isset($user_bonus_data['last_daily_bonus_date']) || $user_bonus_da
                 <p class="text-muted" style="color: #6c757d; margin-top: -10px; margin-bottom: 20px;">
                     Sınağı ən sürətli şəkildə tamamlayaraq <strong>100 xala qədər</strong> bonus qazanın!
                 </p>
+                <div id="timer" class="timer-display">00:00</div>
                 <div class="progress-bar">
                     <div id="progress-bar-inner" class="progress-bar-inner"></div>
                 </div>

--- a/oyun/oyun_skripti.js
+++ b/oyun/oyun_skripti.js
@@ -59,9 +59,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!stageContainer) return;
 
     const progressBar = document.getElementById('progress-bar-inner');
+    const timerEl = document.getElementById('timer');
+    let timerInterval = null;
     let stages = [];
     let currentStageIndex = 0;
     const startTime = Math.floor(Date.now() / 1000);
+
+    function startTimer() {
+        if (!timerEl) return;
+        timerInterval = setInterval(() => {
+            const elapsed = Math.floor(Date.now() / 1000) - startTime;
+            const minutes = String(Math.floor(elapsed / 60)).padStart(2, '0');
+            const seconds = String(elapsed % 60).padStart(2, '0');
+            timerEl.textContent = `${minutes}:${seconds}`;
+        }, 1000);
+    }
 
     function renderCurrentStage() {
         if (currentStageIndex >= stages.length) {
@@ -117,6 +129,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     
     function finishChallenge() {
         progressBar.style.width = '100%';
+        if (timerInterval) clearInterval(timerInterval);
         stageContainer.innerHTML = `<h2 class="game-message success">Təbriklər! Sınağı tamamladınız!</h2><p>Xalınız hesablanır...</p>`;
         
         $.ajax({
@@ -139,6 +152,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (data.error) throw new Error(data.error);
             stages = data.stages;
             renderCurrentStage();
+            startTimer();
         } catch (error) {
             stageContainer.innerHTML = `<p class="game-message error">Sınaq yüklənərkən xəta baş verdi.</p>`;
         }

--- a/oyun/oyun_stili.css
+++ b/oyun/oyun_stili.css
@@ -1,5 +1,6 @@
 /* OYUN ÜÇÜN ÜMUMİ VƏ SINAQ STİLLƏRİ */
 .challenge-wrapper { text-align: center; max-width: 550px; margin: 20px auto; padding: 25px; background-color: #fff; border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+.timer-display { font-size: 18px; font-weight: bold; margin-bottom: 10px; }
 .progress-bar { width: 100%; background-color: #e9ecef; border-radius: 20px; height: 10px; margin-bottom: 20px; overflow: hidden; }
 .progress-bar-inner { width: 0%; background: linear-gradient(90deg, #007bff, #00c6ff); border-radius: 20px; height: 100%; transition: width 0.5s ease; }
 .challenge-stage { min-height: 170px; display: flex; flex-direction: column; justify-content: center; }


### PR DESCRIPTION
## Summary
- add on-screen timer on the daily challenge page
- style timer element in the game CSS
- update game script to start and stop timer

## Testing
- `php -l oyun/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eab550788833383cf0733fb6312f1