### PR TITLE
Improve game UI with sound toggle and overall leaderboard

### DIFF
--- a/oyun/index.php
+++ b/oyun/index.php
@@ -26,7 +26,10 @@ $can_play = (!isset($user_bonus_data['last_daily_bonus_date']) || $user_bonus_da
     <div class="challenge-container">
         <?php if ($can_play): ?>
             <div class="challenge-wrapper">
-                <h1>Gündəlik Sınaq</h1>
+                <div class="challenge-header">
+                    <h1>Gündəlik Sınaq</h1>
+                    <button id="sound-toggle" class="sound-toggle" title="Səsi aç / söndür">🔊</button>
+                </div>
                 <p class="text-muted" style="color: #6c757d; margin-top: -10px; margin-bottom: 20px;">
                     Sınağı ən sürətli şəkildə tamamlayaraq <strong>100 xala qədər</strong> bonus qazanın!
                 </p>
@@ -49,9 +52,10 @@ $can_play = (!isset($user_bonus_data['last_daily_bonus_date']) || $user_bonus_da
 
     <div class="leaderboard-section" style="margin-top: 30px;">
         <div class="leaderboard-grid">
-            <?php 
+            <?php
                 $leaderboard_limit = 10;
-                require_once __DIR__ . '/leaderboard_daily.php'; 
+                require_once __DIR__ . '/leaderboard_daily.php';
+                require_once __DIR__ . '/leaderboard_overall.php';
             ?>
         </div>
     </div>

--- a/oyun/leaderboard_overall.php
+++ b/oyun/leaderboard_overall.php
@@ -1,0 +1,45 @@
+<?php
+// oyun/leaderboard_overall.php
+if (!isset($conn)) { require_once __DIR__ . '/../db.php'; }
+
+$limit = isset($leaderboard_limit) && is_numeric($leaderboard_limit) ? intval($leaderboard_limit) : 5;
+
+$query = "
+    SELECT u.id, u.name, u.profile_picture_url,
+           MIN(dc.completion_time_seconds) AS best_time,
+           COUNT(*) AS play_count
+    FROM daily_challenge_completions dc
+    JOIN users u ON u.id = dc.user_id
+    GROUP BY u.id
+    ORDER BY best_time ASC, play_count DESC
+    LIMIT ?";
+
+$stmt = $conn->prepare($query);
+$stmt->bind_param("i", $limit);
+$stmt->execute();
+$overall_winners = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+?>
+
+<div class="leaderboard-card">
+    <h3>🏅 Ümumi Rekordçular</h3>
+    <?php if(!empty($overall_winners)): ?>
+        <ul>
+            <?php foreach($overall_winners as $index => $user): ?>
+                <li>
+                    <span class="place"><?php echo $index + 1; ?></span>
+                    <img src="<?php echo htmlspecialchars($user['profile_picture_url']); ?>" alt="avatar">
+                    <a href="<?php echo $base_url; ?>/profil.php?id=<?php echo $user['id']; ?>" class="name comment-author-link">
+                        <?php echo htmlspecialchars($user['name']); ?>
+                    </a>
+                    <span class="stat">
+                        🏃 <?php echo $user['best_time']; ?> sn
+                        (<?php echo $user['play_count']; ?>x)
+                    </span>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    <?php else: ?>
+        <p style="padding: 15px; text-align:center; color: #6c757d;">Hələ heç kim sınaq tamamlamayıb.</p>
+    <?php endif; ?>
+</div>

--- a/oyun/oyun_skripti.js
+++ b/oyun/oyun_skripti.js
@@ -5,6 +5,7 @@ const keyClickSound = new Audio("./oyun/files/keyClickSound.mp3");
 const winSound = new Audio("./oyun/files/winSound.mp3");
 const SoundGreen = new Audio("./oyun/files/SoundGreen.mp3");
 const SoundGrayOrange = new Audio("./oyun/files/SoundGrayOrange.mp3");
+let soundEnabled = true;
 
 document.addEventListener('DOMContentLoaded', async () => {
     const board = document.getElementById('game-board');
@@ -115,9 +116,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             dataType: 'json',
             success: function(response) {
                 if (response.status === 'success' && response.correct) {
+                    if (soundEnabled) SoundGreen.play();
                     currentStageIndex++;
                     renderCurrentStage();
                 } else {
+                    if (soundEnabled) SoundGrayOrange.play();
                     messageEl.textContent = 'Təəssüf, səhv cavab. Diqqətlə düşünün!';
                     messageEl.className = 'game-message error';
                     document.getElementById('guess-button').disabled = false;
@@ -130,6 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     function finishChallenge() {
         progressBar.style.width = '100%';
         if (timerInterval) clearInterval(timerInterval);
+        if (soundEnabled) winSound.play();
         stageContainer.innerHTML = `<h2 class="game-message success">Təbriklər! Sınağı tamamladınız!</h2><p>Xalınız hesablanır...</p>`;
         
         $.ajax({
@@ -158,4 +162,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
     
-    loadChallenge();});
+    const soundToggleBtn = document.getElementById('sound-toggle');
+    if (soundToggleBtn) {
+        soundToggleBtn.addEventListener('click', () => {
+            soundEnabled = !soundEnabled;
+            [keyClickSound, winSound, SoundGreen, SoundGrayOrange].forEach(a => a.muted = !soundEnabled);
+            soundToggleBtn.textContent = soundEnabled ? '🔊' : '🔈';
+        });
+    }
+
+    loadChallenge();
+});

--- a/oyun/oyun_stili.css
+++ b/oyun/oyun_stili.css
@@ -1,5 +1,7 @@
 /* OYUN ÜÇÜN ÜMUMİ VƏ SINAQ STİLLƏRİ */
 .challenge-wrapper { text-align: center; max-width: 550px; margin: 20px auto; padding: 25px; background-color: #fff; border-radius: 12px; box-shadow: 0 4px 15px rgba(0,0,0,0.1); }
+.challenge-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.sound-toggle { background: none; border: none; cursor: pointer; font-size: 20px; }
 .timer-display { font-size: 18px; font-weight: bold; margin-bottom: 10px; }
 .progress-bar { width: 100%; background-color: #e9ecef; border-radius: 20px; height: 10px; margin-bottom: 20px; overflow: hidden; }
 .progress-bar-inner { width: 0%; background: linear-gradient(90deg, #007bff, #00c6ff); border-radius: 20px; height: 100%; transition: width 0.5s ease; }


### PR DESCRIPTION
## Summary
- add global leaderboard for the daily challenge
- add sound toggle button in the game header
- hook sounds for correct/wrong answers and winning

## Testing
- `php -l oyun/index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ec19f4d008333b6cde8bd00ef3317